### PR TITLE
add client source address option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # quicssh-rs
 
-> :smile: **quicssh-rs** is a QUIC proxy that allows to use QUIC to connect to an SSH server without needing to patch the client or the server. 
+> :smile: **quicssh-rs** is a QUIC proxy that allows to use QUIC to connect to an SSH server without needing to patch the client or the server.
 
 `quicssh-rs` is [quicssh](https://github.com/moul/quicssh) rust implementation. It is based on [quinn](https://github.com/quinn-rs/quinn) and [tokio](https://github.com/tokio-rs/tokio)
 
 Why use QUIC? Because SSH is vulnerable in TCP connection environments, and most SSH packets are actually small, so it is only necessary to maintain the SSH connection to use it in any network environment. QUIC is a good choice because it has good weak network optimization and an important feature called connection migration. This means that I can switch Wi-Fi networks freely when remote, ensuring a stable SSH connection.
 
 ## Demo
+
 https://user-images.githubusercontent.com/39181969/235409750-234de94a-1189-4288-93c2-45f62a9dfc48.mp4
 
 ## Why not mosh?
+
 Because the architecture of mosh requires the opening of many ports to support control and data connections, which is not very user-friendly in many environments. In addition, vscode remote development does not support mosh.
 
 ## Architecture
@@ -74,18 +76,20 @@ Options:
 $ quicssh-rs client -h
 Client
 
-Usage: quicssh-rs client <URL>
+Usage: quicssh-rs client [OPTIONS] <URL>
 
 Arguments:
-  <URL>  Sewrver address
+  <URL>  Server address
 
 Options:
-  -h, --help     Print help
-  -V, --version  Print version
+  -b, --bind <BIND_ADDR>  Client address
+  -h, --help              Print help
+  -V, --version           Print version
 ```
 
 #### Client SSH Config
-```
+
+```console
 ╰─$ cat ~/.ssh/config
 Host test
     HostName test.test
@@ -93,7 +97,7 @@ Host test
     Port 22333
     ProxyCommand /Users/ouyangjun/code/quicssh-rs/target/release/quicssh-rs client quic://%h:%p
 
-╰─$ ssh test                                                                                                                                                                  
+╰─$ ssh test
 Last login: Mon May  1 13:32:15 2023 from 127.0.0.1
 ```
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,7 +14,7 @@ use log::{debug, error, info, trace, warn, Level};
 #[derive(Parser, Debug)]
 #[clap(name = "client")]
 pub struct Opt {
-    /// Sewrver address
+    /// Server address
     url: Url,
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,6 +16,9 @@ use log::{debug, error, info, trace, warn, Level};
 pub struct Opt {
     /// Server address
     url: Url,
+    /// Client address
+    #[clap(long = "bind", short = 'b')]
+    bind_addr: Option<SocketAddr>,
 }
 
 /// Enables MTUD if supported by the operating system
@@ -98,11 +101,18 @@ pub async fn run(options: Opt) -> Result<(), Box<dyn Error>> {
     info!("[client] Connecting to {:?}", remote);
 
     let endpoint = make_client_endpoint(
-        if remote.is_ipv6() {
-            "[::]:0"
-        }else{
-            "0.0.0.0:0"
-        }.parse().unwrap()
+        match options.bind_addr{
+            None =>{
+                if remote.is_ipv6() {
+                    "[::]:0"
+                }else{
+                    "0.0.0.0:0"
+                }.parse().unwrap()
+            }
+            Some(local)=>{
+                local
+            }
+        }
     )?;
     // connect to server
     let connection = endpoint

--- a/src/client.rs
+++ b/src/client.rs
@@ -97,7 +97,13 @@ pub async fn run(options: Opt) -> Result<(), Box<dyn Error>> {
 
     info!("[client] Connecting to {:?}", remote);
 
-    let endpoint = make_client_endpoint("0.0.0.0:0".parse().unwrap())?;
+    let endpoint = make_client_endpoint(
+        if remote.is_ipv6() {
+            "[::]:0"
+        }else{
+            "0.0.0.0:0"
+        }.parse().unwrap()
+    )?;
     // connect to server
     let connection = endpoint
         .connect(remote, url.host_str().unwrap_or("localhost"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use log::{error, LevelFilter};
 struct Cli {
     #[command(subcommand)]
     command: Commands,
-    /// Location of log, Defalt if 
+    /// Location of log, Default if
     #[clap(value_parser, long = "log")]
     log_file: Option<PathBuf>,
 }
@@ -48,7 +48,6 @@ fn main() {
                 .appender(Appender::builder().build("logfile", Box::new(logfile)))
                 .build(Root::builder().appender("logfile").build(LevelFilter::Info))
                 .unwrap();
-            
         }
         None => {
             let stdout = ConsoleAppender::builder()


### PR DESCRIPTION
- added `--bind`  or `-b` option to specify which address (and port) on the local machine to use as source address.
- with no option, client automatically switches to IPv6 address to connect IPv6 server.