### PR TITLE
feat: select ssh server address

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ Server
 Usage: quicssh-rs server [OPTIONS]
 
 Options:
-  -l, --listen <LISTEN>  Address to listen on [default: 0.0.0.0:4433]
-  -h, --help             Print help
-  -V, --version          Print version
+  -l, --listen <LISTEN>        Address to listen on [default: 0.0.0.0:4433]
+  -p, --proxy-for <PROXY_FOR>  Address of the ssh server [default: 127.0.0.1:22]
+  -h, --help                   Print help
+  -V, --version                Print version
 ```

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Usage: quicssh-rs server [OPTIONS]
 
 Options:
   -l, --listen <LISTEN>        Address to listen on [default: 0.0.0.0:4433]
-  -p, --proxy-for <PROXY_FOR>  Address of the ssh server [default: 127.0.0.1:22]
+  -p, --proxy-to <PROXY_TO>  Address of the ssh server [default: 127.0.0.1:22]
   -h, --help                   Print help
   -V, --version                Print version
 ```

--- a/src/server.rs
+++ b/src/server.rs
@@ -14,8 +14,8 @@ pub struct Opt {
     #[clap(long = "listen", short = 'l', default_value = "0.0.0.0:4433")]
     listen: SocketAddr,
     /// Address of the ssh server
-    #[clap(long = "proxy-for", short = 'p', default_value = "127.0.0.1:22")]
-    proxy_for: SocketAddr,
+    #[clap(long = "proxy-to", short = 'p', default_value = "127.0.0.1:22")]
+    proxy_to: SocketAddr,
 }
 
 /// Returns default server configuration along with its certificate.
@@ -68,7 +68,7 @@ pub async fn run(options: Opt) -> Result<(), Box<dyn Error>> {
             conn.remote_address()
         );
         tokio::spawn(async move {
-            handle_connection(options.proxy_for, conn).await;
+            handle_connection(options.proxy_to, conn).await;
         });
         // Dropping all handles associated with a connection implicitly closes it
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,6 +13,9 @@ pub struct Opt {
     /// Address to listen on
     #[clap(long = "listen", short = 'l', default_value = "0.0.0.0:4433")]
     listen: SocketAddr,
+    /// Address of the ssh server
+    #[clap(long = "proxy-for", short = 'p', default_value = "127.0.0.1:22")]
+    proxy_for: SocketAddr,
 }
 
 /// Returns default server configuration along with its certificate.
@@ -65,14 +68,14 @@ pub async fn run(options: Opt) -> Result<(), Box<dyn Error>> {
             conn.remote_address()
         );
         tokio::spawn(async move {
-            handle_connection(conn).await;
+            handle_connection(options.proxy_for, conn).await;
         });
         // Dropping all handles associated with a connection implicitly closes it
     }
 }
 
-async fn handle_connection(connection: quinn::Connection) {
-    let ssh_stream = TcpStream::connect("127.0.0.1:22").await;
+async fn handle_connection(proxy_for: SocketAddr, connection: quinn::Connection) {
+    let ssh_stream = TcpStream::connect(proxy_for).await;
     let ssh_conn = match ssh_stream {
         Ok(conn) => conn,
         Err(e) => {


### PR DESCRIPTION
server option `--proxy-for` or `-p` specifies the address (and port) of the ssh server.
senarios:
- the ssh server port is changed from default 22, in order to reduce the risk of attacks.
- the server is behind the proxy.