### PR TITLE
ci: add auto publish

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
     name: Rust project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,22 +1,19 @@
+name: Code Lint
 on: [push]
-
-name: build
 
 jobs:
   check:
     name: Rust project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
             toolchain: stable
             override: true
             components: rustfmt, clippy
-
       - name: Cargo format
         run: cargo fmt --all -- --check
-
       - name: Cargo clippy
         run: cargo clippy --all-targets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,12 +98,6 @@ jobs:
           matrix.toolchain == 'stable' &&
           ( startsWith( github.ref, 'refs/tags/v' ) ||
             github.ref == 'refs/tags/test-release' )
-      - name: Publish release artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: quicssh-${{ matrix.platform.os_name }}
-          path: "quicssh-*"
-        if: matrix.toolchain == 'stable' && github.ref == 'refs/tags/test-release'
       - name: Generate SHA-256
         run: shasum -a 256 ${{ matrix.platform.name }}
         if: |
@@ -111,6 +105,12 @@ jobs:
           matrix.platform.os == 'macOS-latest' &&
           ( startsWith( github.ref, 'refs/tags/v' ) ||
             github.ref == 'refs/tags/test-release' )
+      - name: Publish release artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: quicssh-${{ matrix.platform.os_name }}
+          path: "quicssh-*"
+        if: matrix.toolchain == 'stable' && github.ref == 'refs/tags/test-release'
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,5 +130,5 @@ jobs:
         uses: katyo/publish-crates@v2
         with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          dry-run: true
+          dry-run: ${{ startsWith(github.ref, 'refs/tags/test-release') }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  compile:
+  build:
     permissions: write-all
     name: Compile ${{ matrix.platform.os_name }} with Rust ${{ matrix.toolchain }}
     runs-on: ${{ matrix.platform.os }}
@@ -116,17 +116,19 @@ jobs:
     permissions: write-all
     name: publish crate.io release
     runs-on: ubuntu-latest
-    needs: compile
+    needs: build
+    if: (startsWith(github.ref, 'refs/tags/test-release') || startsWith(github.ref,'refs/tags/v'))
     steps:
       - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            override: true
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
       - name: publish crate.io release (dummy)
-        run: cargo publish -n
+        uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          dry-run: true
 
-      # - name: Publish GitHub release
-      #   uses: softprops/action-gh-release@v1
-      #   with:
-      #     draft: true
-      #     files: "quicssh-*"
-      #   if: matrix.toolchain == 'stable' && startsWith( github.ref, 'refs/tags/v' )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,16 +96,22 @@ jobs:
             tar czvf ../../../${{ matrix.platform.name }} ${{ matrix.platform.bin }}
           fi
           cd -
-        if: (github.ref == 'refs/tags/test-release' || startsWith( github.ref, 'refs/tags/v' ))
+        if: (startsWith(github.ref, 'refs/tags/test-release') || startsWith(github.ref,'refs/tags/v'))
       - name: Generate SHA-256
         run: shasum -a 256 ${{ matrix.platform.name }}
-        if: matrix.platform.os == 'macOS-latest' && (github.ref == 'refs/tags/test-release' || startsWith( github.ref, 'refs/tags/v' ))
+        if: (startsWith(github.ref, 'refs/tags/test-release') || startsWith(github.ref,'refs/tags/v'))&&matrix.platform.os == 'macOS-latest'
       - name: Publish release artifacts
         uses: actions/upload-artifact@v3
         with:
           name: quicssh-${{ matrix.platform.os_name }}
           path: "quicssh-*"
-        if: (github.ref == 'refs/tags/test-release' || startsWith( github.ref, 'refs/tags/v' ))
+        if: startsWith(github.ref, 'refs/tags/test-release')
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          files: "quicssh-*"
+        if: matrix.toolchain == 'stable' && startsWith(github.ref,'refs/tags/v')
   crate:
     permissions: write-all
     name: publish crate.io release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
         run: shasum -a 256 ${{ matrix.platform.name }}
         if: (startsWith(github.ref, 'refs/tags/test-release') || startsWith(github.ref,'refs/tags/v'))&&matrix.platform.os == 'macOS-latest'
       - name: Publish release artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: quicssh-${{ matrix.platform.os_name }}
           path: "quicssh-*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,13 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  test:
+  compile:
     permissions: write-all
-    name: ${{ matrix.platform.os_name }} with rust ${{ matrix.toolchain }}
+    name: compile ${{ matrix.platform.os_name }} with rust ${{ matrix.toolchain }}
     runs-on: ${{ matrix.platform.os }}
     strategy:
-      fail-fast: false
+      # assert perfect success
+      fail-fast: true
       matrix:
         platform:
           # Platforms that don't work:
@@ -85,6 +86,7 @@ jobs:
           args: "--locked --release"
           strip: true
       - name: Package as archive
+        # in future we would need bundle etc files
         shell: bash
         run: |
           cd target/${{ matrix.platform.target }}/release
@@ -94,37 +96,31 @@ jobs:
             tar czvf ../../../${{ matrix.platform.name }} ${{ matrix.platform.bin }}
           fi
           cd -
-        if: |
-          matrix.toolchain == 'stable' &&
-          ( startsWith( github.ref, 'refs/tags/v' ) ||
-            github.ref == 'refs/tags/test-release' )
+        if: (github.ref == 'refs/tags/test-release' || startsWith( github.ref, 'refs/tags/v' ))
       - name: Generate SHA-256
         run: shasum -a 256 ${{ matrix.platform.name }}
-        if: |
-          matrix.toolchain == 'stable' &&
-          matrix.platform.os == 'macOS-latest' &&
-          ( startsWith( github.ref, 'refs/tags/v' ) ||
-            github.ref == 'refs/tags/test-release' )
+        if: matrix.platform.os == 'macOS-latest' && (github.ref == 'refs/tags/test-release' || startsWith( github.ref, 'refs/tags/v' ))
       - name: Publish release artifacts
         uses: actions/upload-artifact@v3
         with:
           name: quicssh-${{ matrix.platform.os_name }}
           path: "quicssh-*"
-        if: matrix.toolchain == 'stable' && github.ref == 'refs/tags/test-release'
-      - name: Publish GitHub release
-        uses: softprops/action-gh-release@v1
-        with:
-          draft: true
-          files: "quicssh-*"
-        if: matrix.toolchain == 'stable' && startsWith( github.ref, 'refs/tags/v' )
+        if: (github.ref == 'refs/tags/test-release' || startsWith( github.ref, 'refs/tags/v' ))
   crate:
     permissions: write-all
     name: publish crate.io release
     runs-on: ubuntu-latest
-    needs: test
+    needs: compile
     steps:
       - uses: actions/checkout@v3
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
       - name: publish crate.io release (dummy)
-        run: cargo tree
+        run: cargo publish -n
+
+      # - name: Publish GitHub release
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     draft: true
+      #     files: "quicssh-*"
+      #   if: matrix.toolchain == 'stable' && startsWith( github.ref, 'refs/tags/v' )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,3 +117,14 @@ jobs:
           draft: true
           files: "quicssh-*"
         if: matrix.toolchain == 'stable' && startsWith( github.ref, 'refs/tags/v' )
+  crate:
+    permissions: write-all
+    name: publish crate.io release
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cache cargo & target directories
+        uses: Swatinem/rust-cache@v2
+      - name: publish crate.io release (dummy)
+        run: cargo tree

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
         toolchain:
           - stable
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
       - name: Install musl-tools on Linux
@@ -119,7 +119,7 @@ jobs:
     needs: build
     if: (startsWith(github.ref, 'refs/tags/test-release') || startsWith(github.ref,'refs/tags/v'))
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Tests and release
+name: Test & Release
 
 on:
   push:
@@ -16,7 +16,7 @@ env:
 jobs:
   compile:
     permissions: write-all
-    name: compile ${{ matrix.platform.os_name }} with rust ${{ matrix.toolchain }}
+    name: Compile ${{ matrix.platform.os_name }} with Rust ${{ matrix.toolchain }}
     runs-on: ${{ matrix.platform.os }}
     strategy:
       # assert perfect success

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
           command: "build"
           target: ${{ matrix.platform.target }}
           toolchain: ${{ matrix.toolchain }}
-          args: "--locked --release"
+          args: ${{ (startsWith(github.ref, 'refs/tags/test-release') || startsWith(github.ref,'refs/tags/v')) && '--locked' || '--locked --release' }} # short evaluation emulates ternary conditional operator
           strip: true
       - name: Package as archive
         # in future we would need bundle etc files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
           command: "build"
           target: ${{ matrix.platform.target }}
           toolchain: ${{ matrix.toolchain }}
-          args: ${{ (startsWith(github.ref, 'refs/tags/test-release') || startsWith(github.ref,'refs/tags/v')) && '--locked' || '--locked --release' }} # short evaluation emulates ternary conditional operator
+          args: ${{ (startsWith(github.ref, 'refs/tags/test-release') || startsWith(github.ref,'refs/tags/v')) && '--locked --release' || '--locked' }} # short evaluation emulates ternary conditional operator
           strip: true
       - name: Package as archive
         # in future we would need bundle etc files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
         if: (startsWith(github.ref, 'refs/tags/test-release') || startsWith(github.ref,'refs/tags/v'))
       - name: Generate SHA-256
         run: shasum -a 256 ${{ matrix.platform.name }}
-        if: (startsWith(github.ref, 'refs/tags/test-release') || startsWith(github.ref,'refs/tags/v'))&&matrix.platform.os == 'macOS-latest'
+        if: (startsWith(github.ref, 'refs/tags/test-release') || startsWith(github.ref,'refs/tags/v'))
       - name: Publish release artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "quicssh-rs"
-version = "0.1.3+autobuild"
+version = "0.1.3+autopublish"
 dependencies = [
  "clap",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "quicssh-rs"
-version = "0.1.3"
+version = "0.1.3+autobuild"
 dependencies = [
  "clap",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quicssh-rs"
-version = "0.1.3+autobuild"
+version = "0.1.3+autopublish"
 edition = "2021"
 license = "MIT"
 authors = ["oowl <ouyangjun1999@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quicssh-rs"
-version = "0.1.3"
+version = "0.1.3+autobuild"
 edition = "2021"
 license = "MIT"
 authors = ["oowl <ouyangjun1999@gmail.com>"]


### PR DESCRIPTION
Prerequisites:
- Set `CARGO_REGISTRY_TOKEN` as a github secret.

Usage: 
- Push with a tag starts with `test-release`
  Upload `.gz` files as artifacts.
- Push with a tag starts with `v`
  Upload the files as release, and publish into `crates.io`.

we already have `v0.1.3`, so I recommend to use a tag with build metadata, like ~~`v0.1.3+autobuild`~~ `v0.1.3+autopublish`, used in this PR.