### PR TITLE
feat: Host-based proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/quicssh-rs.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,9 @@ dependencies = [
  "rcgen",
  "rustls",
  "rustls-pemfile 2.1.1",
+ "serde",
  "tokio",
+ "toml",
  "url",
 ]
 
@@ -895,6 +897,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,6 +1084,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.52",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1413,6 +1458,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+
+[[package]]
+name = "winnow"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "yasna"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "quicssh-rs"
-version = "0.1.4+autopublish"
+version = "0.1.5-dev"
 dependencies = [
  "clap",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quicssh-rs"
-version = "0.1.4+autopublish"
+version = "0.1.5-dev"
 edition = "2021"
 license = "MIT"
 authors = ["oowl <ouyangjun1999@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,5 @@ rustls-pemfile = "2.1.1"
 rcgen = "0.12.1"
 log = { version = "0.4.21", features = ["std", "serde"] }
 log4rs = "1.2.0"
+serde = "1.0.197"
+toml = "0.8.12"

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,11 +2,7 @@
 
 use clap::Parser;
 use quinn::{ClientConfig, Endpoint, VarInt};
-use std::{
-    error::Error,
-    net::{SocketAddr, ToSocketAddrs},
-    sync::Arc,
-};
+use std::{error::Error, net::SocketAddr, sync::Arc};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 #[cfg(not(windows))]

--- a/src/client.rs
+++ b/src/client.rs
@@ -95,13 +95,16 @@ pub async fn run(options: Opt) -> Result<(), Box<dyn Error>> {
         return Err("URL scheme must be quic".into());
     }
 
-    //Currently `url` crate doesn't recognize quic as scheme (see socket_addrs()), so we can set default port using argument. In future if quic default port is added (as 80 or 443, likely), we will fail to connect to proper port. Ideally we should define own scheme. (ex. "qsrs://" abbr of quicssh-rs)
+    // Currently `url` crate doesn't recognize quic as scheme (see socket_addrs()), so we can set default port using argument. In future if quic default port is added (as 80 or 443, likely), we will fail to connect to proper port. Ideally we should define own scheme. (ex. "qsrs://" abbr of quicssh-rs)
     let sock_list = url
         .socket_addrs(|| Some(4433))
-        .map_err(|_| "couldn't resolve to any address")?;
-    let remote = sock_list[0];
+        .map_err(|_| "Couldn't resolve to any address")?;
 
-    info!("[client] Connecting to {:?} <- {:?}", remote, url.host());
+    // Currently we only use the first addr. The other addrs should be fallbacks of the connection, but not implemented now.
+    let remote = sock_list[0];
+    let sni = url.host_str().unwrap_or("THIS_HOSTNAME_SHOULD_NOT_BE_USED");
+
+    info!("[client] Connecting to: {} <- {}", remote, sni);
 
     let endpoint = make_client_endpoint(match options.bind_addr {
         Some(local) => local,
@@ -115,15 +118,11 @@ pub async fn run(options: Opt) -> Result<(), Box<dyn Error>> {
         }
     })?;
     // connect to server
-    let connection = endpoint
-        .connect(remote, url.host_str().unwrap_or("localhost"))
-        .unwrap()
-        .await
-        .unwrap();
+    let connection = endpoint.connect(remote, sni).unwrap().await.unwrap();
     info!(
-        "[client] connected: addr={:?} host={}",
+        "[client] Connected to: {} <- {}",
         connection.remote_address(),
-        url.host_str().unwrap_or("dummy")
+        sni
     );
 
     let (mut send, mut recv) = connection

--- a/src/client.rs
+++ b/src/client.rs
@@ -121,9 +121,9 @@ pub async fn run(options: Opt) -> Result<(), Box<dyn Error>> {
         .await
         .unwrap();
     info!(
-        "[client] connected: addr={:?} host={:?}",
+        "[client] connected: addr={:?} host={}",
         connection.remote_address(),
-        url.host()
+        url.host_str().unwrap_or("dummy")
     );
 
     let (mut send, mut recv) = connection

--- a/src/server.rs
+++ b/src/server.rs
@@ -75,12 +75,9 @@ pub async fn run(options: Opt) -> Result<(), Box<dyn Error>> {
 
     let default_proxy = match conf.proxy.get("default") {
         Some(sock) => sock.clone(),
-        None => {
-            use std::net::IpAddr::V4;
-            options
-                .proxy_to
-                .unwrap_or(SocketAddr::new(V4(Ipv4Addr::LOCALHOST), 22))
-        }
+        None => options
+            .proxy_to
+            .unwrap_or(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 22)),
     };
     info!("[server] default proxy aim: {}", default_proxy);
 


### PR DESCRIPTION
## Abstruct

It is a typical situation that there are multiple servers in private network and only one proxy server is accessible from public network(or the Internet). 
TLS enables to deal with the situation using SNI, and is included in QUIC protocol.
In this PR, Host-based routing is implemented using SNI.

## Usage

1. List up the mapping of host names to socketaddrs in conf file.
1. Launch server specifying the conf file path.
1. Run client using domain(host) name in URL.

Example:

- `./quicssh-rs.toml`

```toml
[proxy]
"xxx.example.net"="192.168.0.10:22"
"yyy.example.net"="192.168.0.10:2222"
"zzz.example.net"="192.168.0.20:22"
default="192.168.0.30:22"
```

- launch server

```bash
quicssh-rs server -F ./quicssh-rs.toml
```

- run client
```bash
quicssh-rs client quic://xxx.example.net # -> 192.168.0.10:22
quicssh-rs client quic://yyy.example.net # -> 192.168.0.10:2222
quicssh-rs client quic://zzz.example.net # -> 192.168.0.20:22
quicssh-rs client quic://<raw ip, or other domain name> # -> 192.168.0.30:22
```