### PR TITLE
fix: fix **b**install failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
         uses: cargo-bins/cargo-binstall@v1.6.4
         if: matrix.const.as_r && contains(matrix.platform.target, 'linux')
       - name: BInstall cargo-deb
-        run: cargo binstall -y cargo-deb
+        run: cargo binstall --force -y cargo-deb
         if: matrix.const.as_r && contains(matrix.platform.target, 'linux')
       - name: Build deb package
         run: cargo deb --no-build --no-strip --target ${{ matrix.platform.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "quicssh-rs"
-version = "0.1.5-dev"
+version = "0.1.5"
 dependencies = [
  "clap",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quicssh-rs"
-version = "0.1.5-dev"
+version = "0.1.5"
 edition = "2021"
 license = "MIT"
 authors = ["oowl <ouyangjun1999@gmail.com>"]


### PR DESCRIPTION
Force cargo **b**install to install `cargo-deb` anyway, in order to avoid "zombie" installation.
This PR corresponds to https://github.com/oowl/quicssh-rs/pull/26#issuecomment-2065897848.